### PR TITLE
Update run.tcl with exit command

### DIFF
--- a/lab_vitis_hls/run.tcl
+++ b/lab_vitis_hls/run.tcl
@@ -61,3 +61,4 @@ set argv [list $filename $hls_prj]
 set argc 2
 source "./script/collect_result.tcl"
 }
+exit


### PR DESCRIPTION
Add exit command to exit vitis at end of run.
Maybe it is because I am running this from a bash wrapper script, but vitis does not exit on completion of this script without this line. I am instancing vitis in shell mode with -f like on the lab webpage. Vitis 2022.2